### PR TITLE
add release automation and offense language validation via github act…

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,47 @@
+on:
+  release:
+    types: [published]
+
+name: Upload Release Asset
+
+jobs:
+  build:
+    name: Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Get release
+        id: get_release
+        uses: bruceadams/get-release@v1.2.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+
+      - name: Publish operator image and generate release assets
+        run: |
+          docker login -u="${{ secrets.QUAY_BOT }}" -p="${{ secrets.QUAY_PASSWORD }}" quay.io
+          export IMG_TAG="${{ steps.get_release.outputs.tag_name }}"
+          make release
+
+      - name: Upload kubernetes manifest
+        id: kubernetes-manifest 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
+          asset_name: kubevirt-tekton-tasks-kubernetes
+          asset_content_type: text/plain
+
+      - name: Upload okd manifest
+        id: okd-manifest  
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: manifests/okd/kubevirt-tekton-tasks-okd.yaml
+          asset_name: kubevirt-tekton-tasks-okd
+          asset_content_type: text/plain

--- a/.github/workflows/validate-no-offensive-lang.yml
+++ b/.github/workflows/validate-no-offensive-lang.yml
@@ -1,0 +1,15 @@
+name: validate-no-offensive-lang
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: validate-no-offensive-lang
+      run: scripts/validate-no-offensive-lang.sh

--- a/makefile
+++ b/makefile
@@ -45,6 +45,14 @@ e2e-tests:
 onboard-new-task-with-ci-stub:
 	./scripts/onboard-new-task-with-ci-stub.sh
 
+build-images:
+	./scripts/build-images.sh
+
+push-images:
+	./scripts/push-images.sh
+
+release: build-images push-images
+
 vendor:
 	./scripts/vendor.sh
 
@@ -63,6 +71,7 @@ vendor:
 	cluster-test \
 	cluster-clean \
 	cluster-clean-and-skip-images \
+	release \
 	e2e-tests \
 	onboard-new-task-with-ci-stub \
 	vendor

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ -z "${IMG_TAG}" ]; then
+  echo "IMG_TAG is not defined"
+  exit 1
+fi
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+REPO_DIR="$(realpath "${SCRIPT_DIR}/..")"
+
+source "${SCRIPT_DIR}/release-var.sh"
+source "${SCRIPT_DIR}/common.sh"
+
+
+visit "${REPO_DIR}"
+  visit modules
+    if [[ $# -eq 0 ]]; then
+      TASK_NAMES=(*)
+    else
+      TASK_NAMES=("$@")
+    fi
+    for TASK_NAME in ${TASK_NAMES[*]}; do
+      if echo "${TASK_NAME}" | grep -vqE "^(${EXCLUDED_NON_IMAGE_MODULES})$"; then
+        if [ ! -d  "${TASK_NAME}" ]; then
+          continue
+        fi
+        visit "${TASK_NAME}"
+          IMAGE_NAME_AND_TAG="tekton-task-${TASK_NAME}:${IMG_TAG}"
+          IMAGE="${REGISTRY}/${REPOSITORY}/${IMAGE_NAME_AND_TAG}"
+          podman build -f "build/${TASK_NAME}/Dockerfile" -t "${IMAGE}" .
+        leave
+      fi
+    done
+  leave
+leave

--- a/scripts/push-images.sh
+++ b/scripts/push-images.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ -z "${IMG_TAG}" ]; then
+  echo "IMG_TAG is not defined"
+  exit 1
+fi
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
+source "${SCRIPT_DIR}/release-var.sh"
+source "${SCRIPT_DIR}/common.sh"
+
+for TASK_NAME in ${TASK_NAMES[*]}; do
+    if echo "${TASK_NAME}" | grep -vqE "^(${EXCLUDED_NON_IMAGE_MODULES})$"; then
+    if [ ! -d  "${TASK_NAME}" ]; then
+        continue
+    fi
+    visit "${TASK_NAME}"
+        IMAGE_NAME_AND_TAG="tekton-task-${TASK_NAME}:${IMG_TAG}"
+        export IMAGE="${REGISTRY}/${REPOSITORY}/${IMAGE_NAME_AND_TAG}"
+        podman push "${IMAGE}" --tls-verify=false
+    leave
+    fi
+done

--- a/scripts/release-var.sh
+++ b/scripts/release-var.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+export REGISTRY="quay.io"
+export REPOSITORY="kubevirt"

--- a/scripts/validate-no-offensive-lang.sh
+++ b/scripts/validate-no-offensive-lang.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+OFFENSIVE_WORDS="black[ -]?list|white[ -]?list|master|slave"
+ALLOW_LIST=".+[:/=]master[a-zA-Z]*/?"
+
+if git grep -inE "${OFFENSIVE_WORDS}" -- ':!vendor' ":!${BASH_SOURCE[0]}" ':!.github/workflows/' | grep -viE "${ALLOW_LIST}"; then
+  echo "Validation failed. Found offensive language"
+  exit 1
+fi


### PR DESCRIPTION
…ions

This PR adds release automation, which creates new images and deploy
manifests when new github release is done.
Add script which checks offense language and if any is found, fail test.

Signed-off-by: Karel Šimon <ksimon@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
